### PR TITLE
Connect selector takes input

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ component
   :: forall q i o m
    . MonadStore BS.Action BS.Store m
   => H.Component q i o m
-component = connect selectAll $ H.mkComponent
+component = connect (\_ -> selectAll) $ H.mkComponent
   { initialState: deriveState
   , render: \{ count } -> ...
   , eval: H.mkEval $ H.defaultEval
@@ -163,7 +163,7 @@ component
   :: forall q i o m
    . MonadStore BS.Action BS.Store m
   => H.Component q i o m
-component = connect selectCount $ H.mkComponent
+component = connect (\_ -> selectCount) $ H.mkComponent
   { initialState: deriveState
   , ...
   }

--- a/example/basic-no-action/NoAction/Counter.purs
+++ b/example/basic-no-action/NoAction/Counter.purs
@@ -31,7 +31,7 @@ component
   :: forall q o m
    . MonadStore NAS.Action NAS.Store m
   => H.Component q Unit o m
-component = connect selectState $ H.mkComponent
+component = connect (\_ -> selectState) $ H.mkComponent
   { initialState: deriveState
   , render
   , eval: H.mkEval $ H.defaultEval

--- a/example/basic/Basic/Counter.purs
+++ b/example/basic/Basic/Counter.purs
@@ -28,7 +28,7 @@ selectCount :: Selector BS.Store Int
 selectCount = selectEq _.count
 
 component :: forall q o m. MonadStore BS.Action BS.Store m => H.Component q Unit o m
-component = connect selectCount $ H.mkComponent
+component = connect (\_ -> selectCount) $ H.mkComponent
   { initialState: deriveState
   , render
   , eval: H.mkEval $ H.defaultEval

--- a/example/redux-todo/ReduxTodo/Component/FilterLink.purs
+++ b/example/redux-todo/ReduxTodo/Component/FilterLink.purs
@@ -50,7 +50,7 @@ component
   :: forall q o m
    . MonadStore Store.Action Store.Store m
   => H.Component q Input o m
-component = connect selectState $ H.mkComponent
+component = connect (\_ -> selectState) $ H.mkComponent
   { initialState: deriveState
   , render
   , eval: H.mkEval $ H.defaultEval

--- a/example/redux-todo/ReduxTodo/Component/TodoList.purs
+++ b/example/redux-todo/ReduxTodo/Component/TodoList.purs
@@ -49,7 +49,7 @@ component
   :: forall q o m
    . MonadStore Store.Action Store.Store m
   => H.Component q Unit o m
-component = connect selectState $ H.mkComponent
+component = connect (\_ -> selectState) $ H.mkComponent
   { initialState: deriveState
   , render
   , eval: H.mkEval $ H.defaultEval

--- a/src/Halogen/Store/Connect.purs
+++ b/src/Halogen/Store/Connect.purs
@@ -35,10 +35,10 @@ connect
   :: forall action store context query input output m
    . MonadEffect m
   => MonadStore action store m
-  => Selector store context
+  => (input -> Selector store context)
   -> H.Component query (Connected context input) output m
   -> H.Component query input output m
-connect (Selector selector) component =
+connect mkSelector component =
   H.mkComponent
     { initialState
     , render
@@ -73,6 +73,7 @@ connect (Selector selector) component =
 
   handleAction = case _ of
     Initialize -> do
+      (Selector selector) <- mkSelector <$> H.gets _.input
       subscribe (Selector selector) Update
       context <- map selector.select getStore
       H.modify_ _ { context = Just context }


### PR DESCRIPTION
This PR updates `connect` to accept a function

```purescript
input -> Selector
```

Instead of the `Selector` directly.