### PR TITLE
Migrate UseSelector module and run purs-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,22 +199,27 @@ main = launchAff_ do
   runUI root unit body
 ```
 
-### Using store with hooks 
+### Using `halogen-store` with `halogen-hooks`
 
-If you want to write your component with [Halogen Hooks library](https://github.com/thomashoneyman/purescript-halogen-hooks) ,then you can use `useSelector` hook to access store. It takes selector and return the part of current store retrieved via given selector. 
+If you want to write your component with [Halogen Hooks](https://github.com/thomashoneyman/purescript-halogen-hooks) ,then you can use the `useSelector` hook to access the store.
 
 ```purs
-import Halogen.Hooks as Hooks
-import Halogen.Store.Hooks (useSelector)
-import Halogen.Store.Select (selectAll)
+module Main where
 
-component :: forall q i o m
-           . MonadStore BS.Action BS.Store m
-          => H.Component q i o m
+import Prelude
+
+import Halogen.Hooks as Hooks
+import Halogen.Store.Select (selectAll)
+import Halogen.Store.UseSelector (useSelector)
+
+component
+  :: forall q i o m
+   . MonadStore BS.Action BS.Store m
+  => H.Component q i o m
 component = Hooks.component \_ _ -> Hooks.do
-  ctx <- useSelector selectAll 
+  context <- useSelector selectAll
   Hooks.pure do
     ...
 ```
 
-Unlike the case with connect, though, context returned by `useSelector` hook has type `Maybe store`, because the hook does not have access to store before it has been initialized. 
+Unlike `connect`, the context returned by `useSelector` has the type `Maybe store` because the hook does not have access to the store before it is initialized.

--- a/example/basic-hooks/Basic/Counter.purs
+++ b/example/basic-hooks/Basic/Counter.purs
@@ -8,13 +8,14 @@ import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.Hooks as Hooks
-import Halogen.Store.Hooks.UseSelector (useSelector)
 import Halogen.Store.Monad (class MonadStore, updateStore)
 import Halogen.Store.Select (selectEq)
+import Halogen.Store.UseSelector (useSelector)
 
-component :: forall q i o m
-           . MonadStore BS.Action BS.Store m
-          => H.Component q i o m
+component
+  :: forall q i o m
+   . MonadStore BS.Action BS.Store m
+  => H.Component q i o m
 component = Hooks.component \_ _ -> Hooks.do
   count <- useSelector $ selectEq _.count
   Hooks.pure do
@@ -22,7 +23,7 @@ component = Hooks.component \_ _ -> Hooks.do
     HH.div_
       [ HH.button
           [ HE.onClick \_ -> updateStore BS.Increment ]
-          [ HH.text "Increment"]
+          [ HH.text "Increment" ]
       , HH.text $ " Count: " <> show cnt <> " "
       , HH.button
           [ HE.onClick \_ -> updateStore BS.Decrement ]

--- a/example/basic-no-action/NoAction/Counter.purs
+++ b/example/basic-no-action/NoAction/Counter.purs
@@ -44,7 +44,7 @@ component = connect selectState $ H.mkComponent
     HH.div_
       [ HH.button
           [ HE.onClick \_ -> Increment ]
-          [ HH.text "Increment"]
+          [ HH.text "Increment" ]
       , HH.text $ " Count: " <> show count <> " "
       , HH.button
           [ HE.onClick \_ -> Decrement ]

--- a/example/basic/Basic/Counter.purs
+++ b/example/basic/Basic/Counter.purs
@@ -41,7 +41,7 @@ component = connect selectCount $ H.mkComponent
     HH.div_
       [ HH.button
           [ HE.onClick \_ -> Increment ]
-          [ HH.text "Increment"]
+          [ HH.text "Increment" ]
       , HH.text $ " Count: " <> show count <> " "
       , HH.button
           [ HE.onClick \_ -> Decrement ]

--- a/example/redux-todo/ReduxTodo/Component/AddTodo.purs
+++ b/example/redux-todo/ReduxTodo/Component/AddTodo.purs
@@ -14,7 +14,7 @@ import ReduxTodo.Store.Todos (createTodo)
 import Type.Proxy (Proxy(..))
 import Web.Event.Event (Event, preventDefault)
 
-type Slot id slots = ( addTodo :: H.Slot (Const Void) Void id | slots )
+type Slot id slots = (addTodo :: H.Slot (Const Void) Void id | slots)
 
 addTodo
   :: forall act slots m

--- a/example/redux-todo/ReduxTodo/Component/FilterLink.purs
+++ b/example/redux-todo/ReduxTodo/Component/FilterLink.purs
@@ -15,7 +15,7 @@ import ReduxTodo.Store as Store
 import ReduxTodo.Store.Visibility (Visibility, setVisibility)
 import Type.Proxy (Proxy(..))
 
-type Slot id slots = ( filterLink :: H.Slot (Const Void) Void id | slots )
+type Slot id slots = (filterLink :: H.Slot (Const Void) Void id | slots)
 
 filterLink
   :: forall action id slots m

--- a/example/redux-todo/ReduxTodo/Component/TodoList.purs
+++ b/example/redux-todo/ReduxTodo/Component/TodoList.purs
@@ -19,7 +19,7 @@ import ReduxTodo.Store.Todos (Todo, toggleTodo)
 import ReduxTodo.Store.Visibility (Visibility(..))
 import Type.Proxy (Proxy(..))
 
-type Slot id slots = ( todoList :: H.Slot (Const Void) Void id | slots )
+type Slot id slots = (todoList :: H.Slot (Const Void) Void id | slots)
 
 todoList
   :: forall action slots m

--- a/example/redux-todo/ReduxTodo/Store.purs
+++ b/example/redux-todo/ReduxTodo/Store.purs
@@ -1,6 +1,5 @@
 module ReduxTodo.Store where
 
-
 import Data.Variant (Variant)
 import Data.Variant as Variant
 import ReduxTodo.Store.Todos as Todos

--- a/example/redux-todo/ReduxTodo/Store/Todos.purs
+++ b/example/redux-todo/ReduxTodo/Store/Todos.purs
@@ -51,7 +51,7 @@ reduce store = case _ of
 
     store { todos = newTodos }
 
-type Action' v = ( todos :: Action | v )
+type Action' v = (todos :: Action | v)
 
 injAction :: forall v. Action -> Variant (Action' v)
 injAction = Variant.inj (Proxy :: Proxy "todos")

--- a/example/redux-todo/ReduxTodo/Store/Visibility.purs
+++ b/example/redux-todo/ReduxTodo/Store/Visibility.purs
@@ -41,7 +41,7 @@ reduce store = case _ of
   SetVisibility visibility ->
     store { visibility = visibility }
 
-type Action' v = ( visibility :: Action | v )
+type Action' v = (visibility :: Action | v)
 
 injAction :: forall v. Action -> Variant (Action' v)
 injAction = Variant.inj (Proxy :: Proxy "visibility")

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.1-20210506/packages.dhall sha256:d199e142515f9cc15838d8e6d724a98cd0ca776ceb426b7b36e841311643e3ef
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
 
 in  upstream

--- a/src/Halogen/Store/Connect.purs
+++ b/src/Halogen/Store/Connect.purs
@@ -85,7 +85,7 @@ connect (Selector selector) component =
     Update newContext ->
       H.gets _.context >>= case _ of
         Just oldContext | unsafeRefEq oldContext newContext -> pure unit
-        _ -> H.modify_ _ { context = Just newContext}
+        _ -> H.modify_ _ { context = Just newContext }
 
     Raise output ->
       H.raise output

--- a/src/Halogen/Store/UseSelector.purs
+++ b/src/Halogen/Store/UseSelector.purs
@@ -1,4 +1,4 @@
-module Halogen.Store.Hooks.UseSelector where
+module Halogen.Store.UseSelector where
 
 import Prelude
 
@@ -14,13 +14,13 @@ foreign import data UseSelector :: Type -> Type -> Type -> Hooks.HookType
 type UseSelector' :: Type -> Type -> Type -> Hooks.HookType
 type UseSelector' act store ctx = UseState (Maybe ctx) <> UseEffect <> Hooks.Pure
 
-instance newtypeUseSelector
-  :: HookNewtype (UseSelector act store ctx) (UseSelector' act store ctx)
+instance HookNewtype (UseSelector act store ctx) (UseSelector' act store ctx)
 
-useSelector :: forall m act store ctx
-             . MonadStore act store m
-            => Selector store ctx
-            -> Hook m (UseSelector act store ctx) (Maybe ctx)
+useSelector
+  :: forall m act store ctx
+   . MonadStore act store m
+  => Selector store ctx
+  -> Hook m (UseSelector act store ctx) (Maybe ctx)
 useSelector (Selector selector) = Hooks.wrap hook
   where
   hook :: Hook m (UseSelector' act store ctx) (Maybe ctx)
@@ -29,7 +29,7 @@ useSelector (Selector selector) = Hooks.wrap hook
 
     Hooks.useLifecycleEffect do
       emitter <- emitSelected (Selector selector)
-      subscriptionId <- Hooks.subscribe $ map (Hooks.put ctxId <<< Just) emitter 
+      subscriptionId <- Hooks.subscribe $ map (Hooks.put ctxId <<< Just) emitter
       pure $ Just $ Hooks.unsubscribe subscriptionId
-      
+
     Hooks.pure ctx


### PR DESCRIPTION
This PR does two things:

1. It migrates the `Halogen.Store.Hooks.UseSelector` module to `Halogen.Store.UseSelector`
2. It runs `purs-tidy` on the codebase for consistent formatting