### PR TITLE
Add Instances for StoreT, New MonadStore Instances, Rework MonadAsk Instance

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,6 +1,7 @@
 { name = "halogen-store"
 , dependencies =
   [ "aff"
+  , "distributive"
   , "effect"
   , "foldable-traversable"
   , "halogen"
@@ -9,6 +10,7 @@
   , "maybe"
   , "prelude"
   , "refs"
+  , "tailrec"
   , "transformers"
   , "tuples"
   , "unsafe-coerce"

--- a/src/Halogen/Store/Monad.purs
+++ b/src/Halogen/Store/Monad.purs
@@ -2,8 +2,14 @@ module Halogen.Store.Monad where
 
 import Prelude
 
+import Control.Monad.Cont (class MonadCont)
 import Control.Monad.Error.Class (class MonadError, class MonadThrow)
-import Control.Monad.Reader (class MonadAsk, ReaderT, ask, lift, mapReaderT, runReaderT)
+import Control.Monad.Reader (class MonadAsk, class MonadReader, ReaderT(..), ask, local, lift, mapReaderT, runReaderT)
+import Control.Monad.Rec.Class (class MonadRec)
+import Control.Monad.State (class MonadState)
+import Control.Monad.Trans.Class (class MonadTrans)
+import Control.Monad.Writer (class MonadTell, class MonadWriter)
+import Data.Distributive (class Distributive)
 import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -55,9 +61,19 @@ derive newtype instance MonadEffect m => MonadEffect (StoreT a s m)
 derive newtype instance MonadAff m => MonadAff (StoreT a s m)
 derive newtype instance MonadThrow e m => MonadThrow e (StoreT a s m)
 derive newtype instance MonadError e m => MonadError e (StoreT a s m)
+derive newtype instance MonadTell w m => MonadTell w (StoreT a s m)
+derive newtype instance MonadWriter w m => MonadWriter w (StoreT a s m)
+derive newtype instance MonadState s m => MonadState s (StoreT a s m)
+derive newtype instance MonadCont m => MonadCont (StoreT a s m)
+derive newtype instance MonadRec m => MonadRec (StoreT a s m)
+derive newtype instance Distributive g => Distributive (StoreT a s g)
+derive newtype instance MonadTrans (StoreT a s)
 
-instance MonadEffect m => MonadAsk s (StoreT a s m) where
-  ask = getStore
+instance MonadAsk r m => MonadAsk r (StoreT a s m) where
+  ask = lift ask
+
+instance MonadReader r m => MonadReader r (StoreT a s m) where
+  local f (StoreT (ReaderT r)) = StoreT $ ReaderT $ local f <<< r
 
 instance MonadEffect m => MonadStore a s (StoreT a s m) where
   getStore = StoreT do

--- a/src/Halogen/Store/Monad.purs
+++ b/src/Halogen/Store/Monad.purs
@@ -2,13 +2,17 @@ module Halogen.Store.Monad where
 
 import Prelude
 
-import Control.Monad.Cont (class MonadCont)
+import Control.Monad.Cont (class MonadCont, ContT)
 import Control.Monad.Error.Class (class MonadError, class MonadThrow)
-import Control.Monad.Reader (class MonadAsk, class MonadReader, ReaderT(..), ask, local, lift, mapReaderT, runReaderT)
+import Control.Monad.Except (ExceptT)
+import Control.Monad.Identity.Trans (IdentityT)
+import Control.Monad.Maybe.Trans (MaybeT)
+import Control.Monad.RWS (RWST)
+import Control.Monad.Reader (class MonadAsk, class MonadReader, ReaderT(..), ask, lift, local, mapReaderT, runReaderT)
 import Control.Monad.Rec.Class (class MonadRec)
-import Control.Monad.State (class MonadState)
+import Control.Monad.State (class MonadState, StateT)
 import Control.Monad.Trans.Class (class MonadTrans)
-import Control.Monad.Writer (class MonadTell, class MonadWriter)
+import Control.Monad.Writer (class MonadTell, class MonadWriter, WriterT)
 import Data.Distributive (class Distributive)
 import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
@@ -121,6 +125,46 @@ instance monadStoreHalogenM :: MonadStore a s m => MonadStore a s (HalogenM st a
   emitSelected = lift <<< emitSelected
 
 instance monadStoreHookM :: MonadStore a s m => MonadStore a s (Hooks.HookM m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (ContT r m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (ExceptT e m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (IdentityT m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (MaybeT m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance (MonadStore a s m, Monoid w) => MonadStore a s (RWST r w s m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (ReaderT r m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance MonadStore a s m => MonadStore a s (StateT s m) where
+  getStore = lift getStore
+  updateStore = lift <<< updateStore
+  emitSelected = lift <<< emitSelected
+
+instance (MonadStore a s m, Monoid w) => MonadStore a s (WriterT w m) where
   getStore = lift getStore
   updateStore = lift <<< updateStore
   emitSelected = lift <<< emitSelected


### PR DESCRIPTION
Fixes #13

### Summary of the changes

Add new instances for StoreT

- MonadReader
- MonadTell
- MonadWriter
- MonadState
- MonadCont
- MonadRec
- MonadTrans
- Distributive

Modify MonadAsk instance for StoreT to delegate to the base monad m instead of the wrapped ReaderT (HalogenStore a s)

- MonadAsk - modified to delegate to base monad m with an instance of MonadAsk instead.

Add MonadStore instances for other monad transformers:

- ContT
- IdentityT
- MaybeT
- RWST
- ReaderT
- StateT
- WriterT
