### PR TITLE
Upgrade package set, add runAndEmitStoreT, selectEmitter, fork instances

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.7-20220303/packages.dhall
+        sha256:d7cbc15ea16768e4a4f99baa58a54559dd2648c6c1362de2469d9e41c23b28c3
 
 in  upstream

--- a/shell.nix
+++ b/shell.nix
@@ -10,8 +10,8 @@ let
   pursPkgs = import (pkgs.fetchFromGitHub {
     owner = "justinwoo";
     repo = "easy-purescript-nix";
-    rev = "721bbd957c62594c46ea4c94f1a9f3cb341b2d25";
-    sha256 = "1n72h9y4yfqkk38a2bms1y8qvy6bkdsj27vicf7f9xl92kpzbyab";
+    rev = "aa72388ca0fb72ed64467f59a121db1f104897db";
+    sha256 = "1j37v3ncnakhq7p4l2vqdn4li8bgwcc8cd2hk2fblxhnlglikgx2";
   }) { inherit pkgs; };
 
 in pkgs.stdenv.mkDerivation {

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ in pkgs.stdenv.mkDerivation {
     pursPkgs.spago
     pursPkgs.psa
     pursPkgs.purs-tidy
+    pursPkgs.purescript-language-server
 
     pkgs.nodejs-16_x
   ];

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,6 +4,7 @@
   , "distributive"
   , "effect"
   , "foldable-traversable"
+  , "fork"
   , "halogen"
   , "halogen-hooks"
   , "halogen-subscriptions"

--- a/src/Halogen/Store/Monad.purs
+++ b/src/Halogen/Store/Monad.purs
@@ -183,7 +183,7 @@ runStoreT
   -> H.Component q i o (StoreT a s m)
   -> Aff (H.Component q i o m)
 runStoreT initialStore reducer component =
-  _.root <$> runAndEmitStoreT initialStore reducer component
+  _.component <$> runAndEmitStoreT initialStore reducer component
 
 -- | Run a component in the `StoreT` monad.
 -- |
@@ -203,22 +203,16 @@ runStoreT initialStore reducer component =
 -- | ```purs
 -- | main = do
 -- |   -- load initial store values from local storage.
--- |   field1 <- LocalStorage.getItem "field1"
--- |   ...
--- |   fieldN <- LocalStorage.getItem "fieldN"
--- |   let initialStore = mkStore field1 ... fieldN
+-- |   field <- LocalStorage.getItem "field"
+-- |   let initialStore = mkStore field
 -- |   launchAff_ do
 -- |     body <- Halogen.Aff.awaitBody
--- |     { emitter, root } <- runAndEmitStoreT initialStore reducer rootComponent
--- |     runUI root unit body
--- |     let selectField1 = selectEq _.field1
--- |     let selectFieldN = selectEq _.fieldN
--- |     let subscribe_ = void <<< HS.subscribe
+-- |     { emitter, component } <- runAndEmitStoreT initialStore reducer rootComponent
+-- |     runUI component unit body
+-- |     let selectField = selectEq _.field
 -- |     liftEffect do
--- |       -- save new store values to local storage as they change.
--- |       subscribe_ $ selectEmitter selectField1 emitter $ LocalStorage.setItem "field1"
--- |       ...
--- |       subscribe_ $ selectEmitter selectFieldN emitter $ LocalStorage.setItem "fieldN"
+-- |       -- save new store values to local storage as they change
+-- |       void $ H.subscribe $ selectEmitter selectField emitter $ LocalStorage.setItem "field"
 -- | ```
 runAndEmitStoreT
   :: forall a s q i o m
@@ -226,7 +220,7 @@ runAndEmitStoreT
   => s
   -> (s -> a -> s)
   -> H.Component q i o (StoreT a s m)
-  -> Aff ({ emitter :: Emitter s, root :: H.Component q i o m })
+  -> Aff ({ emitter :: Emitter s, component :: H.Component q i o m })
 runAndEmitStoreT initialStore reducer component = do
   hs <- liftEffect do
     value <- Ref.new initialStore

--- a/src/Halogen/Store/Monad.purs
+++ b/src/Halogen/Store/Monad.purs
@@ -228,7 +228,7 @@ runAndEmitStoreT initialStore reducer component = do
     pure { value, emitter, listener, reducer }
   pure
     { emitter: hs.emitter
-    , root: hoist (\(StoreT m) -> runReaderT m hs) component
+    , component: hoist (\(StoreT m) -> runReaderT m hs) component
     }
 
 -- | Change the type of the result in a `StoreT` monad.

--- a/src/Halogen/Store/Select.purs
+++ b/src/Halogen/Store/Select.purs
@@ -34,10 +34,8 @@ selectEq = Selector <<< { eq, select: _ }
 selectAll :: forall store. Selector store store
 selectAll = Selector { eq: unsafeRefEq, select: identity }
 
--- | Maps an `Emitter` using a `Selector`. The resulting `Emitter` will behave
--- | as if it were `map`ped with the `Selector`'s `select` function, with the
--- | exception that it will not fire multiple times in a row if the selected
--- | value has not changed (as determined by the `Selector`'s `eq` function).
+-- | Apply a `Selector` to an `Emitter` so that the emitter only fires when the
+-- | selected value changes, as determined by the selector's equality function.
 selectEmitter :: forall store a. Selector store a -> Emitter store -> Emitter a
 selectEmitter (Selector selector) emitter =
   HS.makeEmitter \push -> do

--- a/src/Halogen/Store/Select.purs
+++ b/src/Halogen/Store/Select.purs
@@ -2,6 +2,10 @@ module Halogen.Store.Select where
 
 import Prelude
 
+import Data.Maybe (Maybe(..), maybe)
+import Effect.Ref as Ref
+import Halogen.Subscription (Emitter)
+import Halogen.Subscription as HS
 import Unsafe.Reference (unsafeRefEq)
 
 -- | A `Selector` represents a selection `a` from the store `store`. It is
@@ -29,3 +33,20 @@ selectEq = Selector <<< { eq, select: _ }
 -- | Create a `Selector` for the entire store.
 selectAll :: forall store. Selector store store
 selectAll = Selector { eq: unsafeRefEq, select: identity }
+
+-- | Maps an `Emitter` using a `Selector`. The resulting `Emitter` will behave
+-- | as if it were `map`ped with the `Selector`'s `select` function, with the
+-- | exception that it will not fire multiple times in a row if the selected
+-- | value has not changed (as determined by the `Selector`'s `eq` function).
+selectEmitter :: forall store a. Selector store a -> Emitter store -> Emitter a
+selectEmitter (Selector selector) emitter =
+  HS.makeEmitter \push -> do
+    previousDerivedRef <- Ref.new Nothing
+    subscription <- HS.subscribe emitter \store -> do
+      previousDerived <- Ref.read previousDerivedRef
+      let newDerived = selector.select store
+      let isUnchanged = maybe false (selector.eq newDerived) previousDerived
+      unless isUnchanged do
+        Ref.write (Just newDerived) previousDerivedRef
+        push newDerived
+    pure $ HS.unsubscribe subscription


### PR DESCRIPTION
## Summary

This PR contains the following changes:

- [x] Upgrades package set to [0.14.7-20220303](https://github.com/thomashoneyman/purescript-halogen-store/commit/52cde690c8557a1111b21a2f692bdbb92dec49e2) and PureScript 0.14.7 52cde690c8557a1111b21a2f692bdbb92dec49e2
- [x] Adds purescript-language-server to the nix shell 8a09a591400fe20f5f5c09735ef3f605236c5016
- [x] Adds a new entrypoint API `runAndEmitStoreT` fd6031ba87d8a4a683ca2c212345701c6e1481a6
- [x] Extracts the logic of applying a selector to and emitter from `emitSelected` to `selectEmitter` (this makes `runAndEmitStoreT` more ergonomic to use in a performant way) d2450ab2d5d4947e31b449646ffefc9921183301
  - This change includes a bugfix: The `Emitter` returned by `emitSelected` cannot be subscribed to multiple times (which can also happen implicitly when using higher-order combinators with the resulting emitter, e.g. `<*>` and `<|>`). This was due to the mutable `Ref` used to track the previous derived value being shared between subscribers. Now a new mutable ref is created for each new subscriber.
- [x] Adds `StoreT` instances for `purescript-fork` typeclasses: `MonadFork`, `MonadKill`, `MonadBracket` 25f5340

## Details

### `runAndEmitStoreT`

Adds a new entrypoint API function that allows the caller to obtain an
emitter from the store in addition to a component. This can be used to
react to store changes outside of the component.

An example application for this is persisting values from the store to
local storage or some other persistence mechanism. Without this
capability, one must perform these tasks inside their Halogen component's
`handleAction` when they receive new Input. This couples the component
with the persistence layer. Even if the concrete persistence mechanism is
injected, the component will still be aware that persistence is required.

With this concern handled outside the component, a "plug-in" style of
architecture is enabled, allowing the driver to opt-in or out of
persistence as desired. For example, a test driver that hosts a
component does not need to mock or configure any peristence layer to run
the component, but a production driver is still free to do so as
required.

###  `selectEmitter`

Moved the logic of applying a selector to an emitter from
Halogen.Store.Monad to Halogen.Store.Select in a new function
`selectEmitter`. This allows the logic of applying a selector to an
emitter to be reused outside of `selectEmitted`, for example, when
running an application via `runAndEmitStoreT`.